### PR TITLE
fix: handle ResponseIds variant and cleanup

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1473,7 +1473,7 @@ async fn submission_loop(
                 let temp_client = turn_context
                     .client
                     .clone_with_session_id(uuid::Uuid::new_v4());
-                let mut temp_turn_context = TurnContext {
+                let temp_turn_context = TurnContext {
                     client: temp_client,
                     tools_config: turn_context.tools_config.clone(),
                     user_instructions: turn_context.user_instructions.clone(),

--- a/codex-rs/core/src/compact/mod.rs
+++ b/codex-rs/core/src/compact/mod.rs
@@ -9,8 +9,6 @@ mod snapshot;
 
 pub(crate) use estimate::CompactionReport;
 pub(crate) use estimate::estimate_tokens_for_items;
-pub(crate) use snapshot::SummaryV1;
-pub(crate) use snapshot::persist_snapshot_atomic;
 
 /// Format a short, human-friendly completion message for the compaction step.
 ///

--- a/codex-rs/core/src/compact/snapshot.rs
+++ b/codex-rs/core/src/compact/snapshot.rs
@@ -45,6 +45,7 @@ pub(crate) struct Symbol {
 }
 
 /// Persist `SummaryV1` to `<codex_home>/session.json` using an atomic write.
+#[allow(dead_code)]
 pub(crate) fn persist_snapshot_atomic(
     codex_home: &Path,
     snapshot: &SummaryV1,

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -559,6 +559,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
             EventMsg::ShutdownComplete => return CodexStatus::Shutdown,
             EventMsg::ConversationHistory(_) => {}
             EventMsg::UserMessage(_) => {}
+            EventMsg::ResponseIds(_) => {}
         }
         CodexStatus::Running
     }

--- a/codex-rs/mcp-server/src/codex_tool_runner.rs
+++ b/codex-rs/mcp-server/src/codex_tool_runner.rs
@@ -280,6 +280,7 @@ async fn run_codex_tool_session_inner(
                     | EventMsg::TurnAborted(_)
                     | EventMsg::ConversationHistory(_)
                     | EventMsg::UserMessage(_)
+                    | EventMsg::ResponseIds(_)
                     | EventMsg::ShutdownComplete => {
                         // For now, we do not do anything extra for these
                         // events. Note that

--- a/docs/codex/CODEX.md
+++ b/docs/codex/CODEX.md
@@ -1,0 +1,5 @@
+# CODEX
+
+- `cargo check -p codex-core`
+- `cargo check -p codex-exec`
+- `cargo check -p codex-mcp-server`

--- a/docs/codex/COMMITS.md
+++ b/docs/codex/COMMITS.md
@@ -1,0 +1,6 @@
+# Commits
+
+## fix: handle ResponseIds variant and clean unused code
+- trim unused snapshot exports
+- ignore ResponseIds events in exec and mcp-server
+- drop needless mut in temp_turn_context

--- a/docs/codex/SESSION.md
+++ b/docs/codex/SESSION.md
@@ -1,0 +1,3 @@
+# Session
+
+Handled compile warnings and ResponseIds variant.


### PR DESCRIPTION
# What
- handle `EventMsg::ResponseIds` in exec and mcp-server
- remove unused snapshot exports and mut
- document session notes

# Why
- unhandled enum variant caused compile errors
- unused snapshot helpers triggered warnings

# How
- added no-op match arms for `ResponseIds`
- trimmed unused re-exports and redundant `mut`
- recorded commit/session docs

# Tests
- `cargo fmt --all`
- `cargo clippy -p codex-core -- -D warnings` *(fails: collapsible_if, uninlined-format-args, expect-used, etc.)*
- `cargo check -p codex-core`
- `cargo check -p codex-exec`
- `cargo check -p codex-mcp-server`
- `cargo test -p codex-core` *(interrupted)*

# Perf
- n/a

# Follow-ups
- clean up remaining clippy lints in core

------
https://chatgpt.com/codex/tasks/task_e_68c1df9245f08322ad7d342bd31f8c38